### PR TITLE
Fixed jumping effect reaching min size

### DIFF
--- a/SPUserResizableView+Pion.podspec
+++ b/SPUserResizableView+Pion.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name         = 'SPUserResizableView+Pion'
-  s.version      = '0.5.3'
+  s.version      = '0.5.4'
   s.license      =  'MIT'
   s.homepage     = 'https://github.com/pionl/SPUserResizableView'
   s.authors      =  'Stephen Poletto'
@@ -8,7 +8,7 @@ Pod::Spec.new do |s|
 
 # Source Info
   s.platform     =  :ios, '5.0'
-  s.source       =  {:git => 'https://github.com/pionl/SPUserResizableView.git', :tag => '0.5.3'}
+  s.source       =  {:git => 'https://github.com/pionl/SPUserResizableView.git', :tag => '0.5.4'}
   s.source_files = 'SPUserResizableView/SPUserResizableView.{h,m}'
   s.requires_arc = true
   

--- a/SPUserResizableView.xcodeproj/project.pbxproj
+++ b/SPUserResizableView.xcodeproj/project.pbxproj
@@ -192,8 +192,10 @@
 			buildSettings = {
 				ALWAYS_SEARCH_USER_PATHS = NO;
 				ARCHS = "$(ARCHS_STANDARD_32_BIT)";
+				CLANG_ENABLE_OBJC_WEAK = YES;
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
 				COPY_PHASE_STRIP = NO;
+				ENABLE_BITCODE = NO;
 				GCC_C_LANGUAGE_STANDARD = gnu99;
 				GCC_DYNAMIC_NO_PIC = NO;
 				GCC_OPTIMIZATION_LEVEL = 0;
@@ -216,8 +218,10 @@
 			buildSettings = {
 				ALWAYS_SEARCH_USER_PATHS = NO;
 				ARCHS = "$(ARCHS_STANDARD_32_BIT)";
+				CLANG_ENABLE_OBJC_WEAK = YES;
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
 				COPY_PHASE_STRIP = YES;
+				ENABLE_BITCODE = NO;
 				GCC_C_LANGUAGE_STANDARD = gnu99;
 				GCC_VERSION = com.apple.compilers.llvm.clang.1_0;
 				GCC_WARN_ABOUT_MISSING_PROTOTYPES = YES;

--- a/SPUserResizableView/SPUserResizableView.m
+++ b/SPUserResizableView/SPUserResizableView.m
@@ -326,11 +326,11 @@ static SPUserResizableViewAnchorPoint SPUserResizableViewLowerMiddleAnchorPoint 
     
     // (4) If the new frame is too small, cancel the changes.
     if (newWidth < self.minWidth) {
-        newX -= self.minWidth - newWidth;
+        newX -= anchorPoint.adjustsX * (self.minWidth - newWidth);
         newWidth = self.minWidth;
     }
     if (newHeight < self.minHeight) {
-        newY -= self.minHeight - newHeight;
+        newY -= anchorPoint.adjustsY * (self.minHeight - newHeight);
         newHeight = self.minHeight;
     }
     

--- a/SPUserResizableView/SPUserResizableView.m
+++ b/SPUserResizableView/SPUserResizableView.m
@@ -326,12 +326,12 @@ static SPUserResizableViewAnchorPoint SPUserResizableViewLowerMiddleAnchorPoint 
     
     // (4) If the new frame is too small, cancel the changes.
     if (newWidth < self.minWidth) {
+        newX -= self.minWidth - newWidth;
         newWidth = self.minWidth;
-        newX = self.frame.origin.x;
     }
     if (newHeight < self.minHeight) {
+        newY -= self.minHeight - newHeight;
         newHeight = self.minHeight;
-        newY = self.frame.origin.y;
     }
     
     // (5) Ensure the resize won't cause the view to move offscreen.


### PR DESCRIPTION
When you resize the element with upper/left anchors and reach either min height or min width the element sort of "jumps" up/left.

It happens because element's size is increased exceptionally setting it to minWidth/minHeight while calculated newWidth/newHeight was smaller. The bad thing is that newX/newY are not recalculated in this case which leads to jumping effect.

The fix is decreasing newX/newY with same amount as newWidth/newHeight are increased with thus leaving the element at the same place.
